### PR TITLE
Fix Slack link.

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,4 +9,3 @@ Welcome to the Call for Code organization on GitHub where we love all things tec
 * :octocat: 70+ GitHub repositories. Search below! Or check out the [Project Catalog](https://github.com/Call-for-Code/Project-Catalog)
 * :calendar: Join our [public project town halls and special interest group meetings](https://calendar.google.com/calendar/embed?src=4n0hu4ojlfufu4s7c5jsck77rs%40group.calendar.google.com&ctz=America%2FNew_York)
 * :sparkles: Say hello in our [Slack community](http://callforcode.org/slack)
-

--- a/profile/README.md
+++ b/profile/README.md
@@ -8,4 +8,5 @@ Welcome to the Call for Code organization on GitHub where we love all things tec
 * :rocket: 14 official [open source projects hosted by The Linux Foundation](https://www.linuxfoundation.org/projects/call-for-code/)
 * :octocat: 70+ GitHub repositories. Search below! Or check out the [Project Catalog](https://github.com/Call-for-Code/Project-Catalog)
 * :calendar: Join our [public project town halls and special interest group meetings](https://calendar.google.com/calendar/embed?src=4n0hu4ojlfufu4s7c5jsck77rs%40group.calendar.google.com&ctz=America%2FNew_York)
-* :sparkles: Say hello in our [Slack community](https://img.shields.io/static/v1?label=Community&message=%23open-source-general&color=blue)
+* :sparkles: Say hello in our [Slack community](http://callforcode.org/slack)
+


### PR DESCRIPTION
The original link was pointed to
a random badge, so it was replaced by
http://callforcode.org/slack